### PR TITLE
fix: 路径环境不一

### DIFF
--- a/Thesis/setup/format.tex
+++ b/Thesis/setup/format.tex
@@ -257,7 +257,7 @@
 
   \begin{figure}[h]
   \centering
-  \centerline{\includegraphics[width=\textwidth]{Thesis/figures/sdulogo.jpg}}
+  \centerline{\includegraphics[width=\textwidth]{figures/sdulogo.jpg}}
   \end{figure}
   
   \vspace*{-4em}


### PR DESCRIPTION
统一tex编译路径在Thesis/文件夹内，移除图片路径前缀